### PR TITLE
feat: Maintain local context in lib instead of relying on page stores

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -96,11 +96,14 @@ You can now use the library on any page/layout like this
 
 ```html
 <script lang="ts">
-	import { signIn, signOut } from 'svelte-google-auth/client';
-	import { user } from 'svelte-google-auth/store';
+	import { signIn, signOut, initialize } from 'svelte-google-auth/client';
+	import type { PageData } from './$types.js';
+
+	export let data: PageData;
+	initialize(data);
 </script>
 
-{$user?.name}
+{data.auth.user?.name}
 <button on:click={() => signIn()}>Sign In</button>
 <button on:click={() => signOut()}>Sign Out</button>
 ```

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-	import { signIn, signOut } from '$lib/client.js';
+	import { signIn, signOut, initialize } from '$lib/client.js';
 	import type { PageData } from './$types.js';
 
 	export let data: PageData;
+	initialize(data);
+
 	console.log('data', data);
 </script>
 


### PR DESCRIPTION
The current implementation tried to load the page store inside the library. This works when library is loaded locally, but not when its loaded from npm. So moving away from doing so, this solution instead stores the needed variables in a global variable inside the library when `initialize` is called. 