### PR TITLE
feat: Enable requests that contain bearer token

### DIFF
--- a/src/routes/bearer-token/+page.svelte
+++ b/src/routes/bearer-token/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { signOut } from '$lib/client.js';
+	import type { PageData } from './$types.js';
+	export let data: PageData;
+
+	const apiDataPromise =
+		browser &&
+		fetch('/bearer-token/api', {
+			credentials: 'omit',
+			headers: {
+				Authorization: `Bearer ${data.auth.access_token}`
+			}
+		}).then((res) => res.json());
+</script>
+
+<h1>Example of requesting authentication using bearer token.</h1>
+
+{#await apiDataPromise}
+	Fetching...
+{:then apiData}
+	<pre>
+{JSON.stringify(apiData, null, 2)}
+	</pre>
+{/await}
+
+<button on:click={() => signOut()}>Sign out</button>

--- a/src/routes/bearer-token/api/+server.ts
+++ b/src/routes/bearer-token/api/+server.ts
@@ -1,0 +1,7 @@
+import { getAuthLocals } from '$lib/server.js';
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types.js';
+
+export const GET: RequestHandler = async ({ locals }) => {
+	return json(getAuthLocals(locals).user);
+};


### PR DESCRIPTION
This feature will allow requests to sveltekit that contain a bearer access token instead of a id token cookie. 